### PR TITLE
Patching to provide webkit support for icons

### DIFF
--- a/docs/assets/scss/hugo-uswds-custom.scss
+++ b/docs/assets/scss/hugo-uswds-custom.scss
@@ -26,7 +26,7 @@
 .usa-banner__button {
   @include at-media("tablet") {
     &:after {
-    -webkit-mask:  url(http://localhost:1313/oscal-tools//img/usa-icons/expand_more.svg) no-repeat center
+    -webkit-mask: url(https://pages.nist.gov/oscal-tools/img/usa-icons/expand_more.svg) no-repeat center
     }
   }
 }

--- a/docs/assets/scss/hugo-uswds-custom.scss
+++ b/docs/assets/scss/hugo-uswds-custom.scss
@@ -18,3 +18,19 @@
     float: inherit;
   }
 }
+
+.usa-site-alert--info .usa-alert:before {
+    -webkit-mask-image: url(https://pages.nist.gov/oscal-tools/img/usa-icons/info.svg);
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    }
+
+.usa-banner__button {
+  @include at-media("tablet") {
+    &:after {
+    -webkit-mask-image: url(http://localhost:1313/oscal-tools//img/usa-icons/expand_more.svg);
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    }
+  }
+}

--- a/docs/assets/scss/hugo-uswds-custom.scss
+++ b/docs/assets/scss/hugo-uswds-custom.scss
@@ -20,17 +20,13 @@
 }
 
 .usa-site-alert--info .usa-alert:before {
-    -webkit-mask-image: url(https://pages.nist.gov/oscal-tools/img/usa-icons/info.svg);
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-position: center;
+    -webkit-mask: url(https://pages.nist.gov/oscal-tools/img/usa-icons/info.svg) no-repeat center
     }
 
 .usa-banner__button {
   @include at-media("tablet") {
     &:after {
-    -webkit-mask-image: url(http://localhost:1313/oscal-tools//img/usa-icons/expand_more.svg);
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-position: center;
+    -webkit-mask:  url(http://localhost:1313/oscal-tools//img/usa-icons/expand_more.svg) no-repeat center
     }
   }
 }


### PR DESCRIPTION
In case we wish to mitigate the Issue that gives rise to a small but glaring display bug (dropped image icons in Chrome/webkit).

The bug is addressed in https://github.com/uswds/uswds/pull/4404.