### PR TITLE
XSLT Updates

### DIFF
--- a/xslt/publish/css/oscal-catalog_html.css
+++ b/xslt/publish/css/oscal-catalog_html.css
@@ -4,11 +4,11 @@
 .UNKNOWN .tag { color: darkred }
 
 .lbl { background-color: midnightblue; color: white;
-  font-size: 80%; font-weight: bold; font-family: sans-serif;
+  font-size: 80%; font-weight: bold; font-family: Calibri, sans-serif;
   padding: 0.2em 0.5em; margin: 0em 0.5em 0em 0em }
 
 .lbl2 { background-color: white; color: black; border: thin solid black;
-  font-size: 80%; font-weight: bold; font-family: sans-serif;
+  font-size: 80%; font-weight: bold; font-family: Calibri, sans-serif;
   padding: 0.2em 0.5em; margin: 0em 0.5em 0em 0em }
 
 .metadata, section.ToC { padding: 0.4em; border: thin solid black; margin-top: 1em }
@@ -19,7 +19,7 @@
 
 div > .line { margin: 0.5em 0em 0em 0em }
 
-section.ToC { font-family: sans-serif }
+section.ToC { font-family: Calibri, sans-serif }
 
 div.ToC { margin-left: 2em; margin-top: 0em }
 details p.toc-listing { margin: 0em 0em 0em 1em }
@@ -30,7 +30,7 @@ div.enhancements p.toc-listing { display: inline-block }
 .toc-title { font-weight: bold }
 .enhancements .toc-title { font-weight: inherit; font-size: 80% }
 
-.withdrawn-status { font-family: sans-serif; font-size: 90%; font-style: italic }
+.withdrawn-status { font-family:  Calibri, sans-serif; font-size: 90%; font-style: italic }
 
 .description {  }
 
@@ -45,10 +45,10 @@ div.enhancements p.toc-listing { display: inline-block }
 .annotation:hover { background-color: lemonchiffon }
 
 .roles { margin-top: 0.5em; padding: 0.5em; background-color: gainsboro }
-.roles:before { content: "Roles:"; display: block; font-family: sans-serif; font-size: 80% }
+.roles:before { content: "Roles:"; display: block; font-family:  Calibri, sans-serif; font-size: 80% }
 
 .parties { margin-top: 0.5em; padding: 0.5em; background-color: gainsboro }
-.parties:before { content: "Parties:"; display: block; font-family: sans-serif; font-size: 80%  }
+.parties:before { content: "Parties:"; display: block; font-family:  Calibri, sans-serif; font-size: 80%  }
 
 
 .metadata details div.role { background-color: white; border: thin dotted black; padding: 0.5em;
@@ -69,7 +69,7 @@ div.enhancements p.toc-listing { display: inline-block }
 
 
 span.badge { color: midnightblue;
-  font-family: sans-serif; font-weight: bold; border-radius: 0.25em;
+  font-family:  Calibri, sans-serif; font-weight: bold; border-radius: 0.25em;
   padding: 0.25em; border: thin solid midnightblue; margin-right: 0.25em }
 
 span.label { font-weight: normal; padding: 0em 0.5em 0em 0em }
@@ -88,14 +88,14 @@ div.statement div:hover { border: medium solid lightsteelblue }
 
 div.none { display: none }
 
-summary > h2, summary > h3, summary > h4 { display: inline-block; font-family: sans-serif }
+summary > h2, summary > h3, summary > h4 { display: inline-block; font-family:  Calibri, sans-serif }
 
 summary > .head:after { content: ': ' }
 
 summary > h1, summary > h2, summary > h3, summary > h4 { max-width: 80%;
   vertical-align: top; margin: 0em }
 
-h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, .head { font-family: sans-serif }
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, .head { font-family:  Calibri, sans-serif }
 
 .h1 { font-size: 2em;    font-weight: bold }
 .h2 { font-size: 1.5em;  font-weight: bold }
@@ -104,10 +104,10 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, .head { font-family: sans-
 .h5 { font-size: .83em;  font-weight: bold }
 .h6 { font-size: .67em;  font-weight: bold }
 
-p .inline-head { text-decoration: underline; font-family: sans-serif; font-size: 90% }
+p .inline-head { text-decoration: underline; font-family:  Calibri, sans-serif; font-size: 90% }
 
 .insert { font-style: italic; font-weight: bold }
-.insert a { font-size: 80%; font-weight: bold; font-family: sans-serif }
+.insert a { font-size: 80%; font-weight: bold; font-family:  Calibri, sans-serif }
 
 .group { border-top: thin solid black; padding: 0.5em 0em }
 
@@ -157,11 +157,11 @@ a:hover { text-decoration: underline }
 
 
 .lbl { background-color: midnightblue; color: white;
-  font-size: 80%; font-weight: bold; font-family: sans-serif;
+  font-size: 80%; font-weight: bold; font-family:  Calibri, sans-serif;
   padding: 0.2em 0.5em; margin: 0em 0.5em 0em 0em }
 
 .lbl2 { display: inline-block; border: thin solid black;
-  font-size: 80%; font-family: sans-serif;
+  font-size: 80%; font-family: Calibri, sans-serif;
   padding: 0.2em 0.5em; margin: 0em 0.5em 0em 0em }
 
 .metadata { padding: 0.4em; border: thin solid black }
@@ -209,11 +209,14 @@ div > .line { margin: 0.5em 0em 0em 0em }
 .role {  }
 
 .roles { margin-top: 0.5em; padding: 0.5em; background-color: gainsboro }
-.roles:before { content: "Roles:"; display: block; font-family: sans-serif; font-size: 80% }
+.roles:before { content: "Roles:"; display: block; font-family: Calibri, sans-serif; font-size: 80% }
 
 .parties { margin-top: 0.5em; padding: 0.5em; background-color: gainsboro }
-.parties:before { content: "Parties:"; display: block; font-family: sans-serif; font-size: 80%  }
+.parties:before { content: "Parties:"; display: block; font-family: Calibri, sans-serif; font-size: 80%  }
 
+table.objective-table td { padding: 0.4em; font-family: Calibri, sans-serif; border-bottom: thin solid black; border-top: thin solid black; }
+
+.assessment-label { background-color: gainsboro }
 
 .metadata details div.role { background-color: white; border: thin dotted black; padding: 0.5em;
   display: inline-block; margin: 1em 0em 0em 0em; vertical-align: top }

--- a/xslt/publish/css/oscal-catalog_html.css
+++ b/xslt/publish/css/oscal-catalog_html.css
@@ -234,3 +234,5 @@ table.objective-table td { padding: 0.4em; font-family: Calibri, sans-serif; bor
 
 .resource td { padding-top: 0.5em }
 .resource td.title { width: 10% }
+
+tr.resource:nth-child(odd) { background-color: gainsboro }

--- a/xslt/publish/generic-preview/oscal_catalog_html.xsl
+++ b/xslt/publish/generic-preview/oscal_catalog_html.xsl
@@ -11,6 +11,10 @@
    
    <xsl:import href="oscal_metadata_html.xsl"/>
    
+<!-- Note on use of labels:
+   Where a prop[@name='label'] is assumed to appear in the input, only the first of these
+   given (in document) is called for - look for prop[@name='label'][1]
+   -->
    
    
    <xsl:param name="css-path" as="xs:string" select="''"/>
@@ -96,7 +100,7 @@
    
    <xsl:template match="control" mode="toc-listing">
       <p class="toc-listing">
-         <xsl:apply-templates mode="#current" select="prop[@name='label']"/>
+         <xsl:apply-templates mode="#current" select="prop[@name='label'][1]"/>
          <xsl:text> </xsl:text>
          <xsl:apply-templates mode="#current" select="title"/>
       </p>
@@ -123,7 +127,7 @@
          </a>
          <span class="toc-title">
             <xsl:text> (</xsl:text>
-            <xsl:value-of select="(prop[@name='label'],../@id/upper-case(.))[1]"/>
+            <xsl:value-of select="(prop[@name='label']/@value,../@id/upper-case(.))[1]"/>
             <xsl:text>)</xsl:text>
          </span>
       </summary>
@@ -136,7 +140,7 @@
    </xsl:template>
    
    <xsl:template priority="2" match="control/control/prop[@name='label']" mode="toc-listing">
-      <xsl:variable name="parent-label" select="../parent::control/prop[@name='label']/@value"/>
+      <xsl:variable name="parent-label" select="../parent::control/prop[@name='label'][1]/@value"/>
       <span class="toc-label">
          <xsl:value-of select="substring-after(@value,$parent-label)"/>
       </span>
@@ -263,7 +267,7 @@
    
    <xsl:template match="control" mode="badge">
       <span class="badge">
-         <xsl:for-each select="prop[@name='label']">
+         <xsl:for-each select="prop[@name='label'][1]">
             <xsl:value-of select="@value"/>
          </xsl:for-each>
       </span>

--- a/xslt/publish/generic-preview/oscal_catalog_html.xsl
+++ b/xslt/publish/generic-preview/oscal_catalog_html.xsl
@@ -423,7 +423,7 @@
    </xsl:template>
    
    <xsl:template match="control" mode="link-as-link" expand-text="true">
-      <a href="#{ @id }">{ prop[@name='label']/@value }</a>
+      <a href="#{ @id }">{ prop[@name='label'][1]/@value }</a>
    </xsl:template>
    
    <xsl:template priority="2" match="resource[empty(rlink)]" mode="link-as-link">

--- a/xslt/publish/nist-emulation/sp800-53A-catalog_html.xsl
+++ b/xslt/publish/nist-emulation/sp800-53A-catalog_html.xsl
@@ -8,20 +8,6 @@
 
    <xsl:import href="../generic-preview/oscal_catalog_html.xsl"/>
    
-<!--  
-   
-   
-   x  confirm run on old data / tweak
-   x confirm run on new data
-   x run to PDF
-   o rename 'objective-part' as 'statement-part'?
-   x paste screen shot
-   o update comments
-   o PR
-   o CSX: catalog display
-   
-   -->
-   
    <!-- Space can be stripped from anything modeled as an assembly. -->
    <xsl:strip-space elements="catalog group control param guideline select part
       metadata back-matter annotation party person org rlink address resource role responsible-party citation

--- a/xslt/publish/nist-emulation/sp800-53A-catalog_html.xsl
+++ b/xslt/publish/nist-emulation/sp800-53A-catalog_html.xsl
@@ -48,7 +48,7 @@
             </xsl:if>
             <summary class="h3">
                <span class="label">
-                  <xsl:apply-templates mode="part-number" select="prop[@name = 'label']"/>
+                  <xsl:apply-templates mode="part-number" select="prop[@name = 'label'][1]"/>
                </span>
                <xsl:for-each select="ancestor::control/title">
                   <small>
@@ -198,13 +198,22 @@
       </div>
    </xsl:template>
    
-   <xsl:template match="part[@name='assessment']/prop[@name='method']"/>   
+   <xsl:template match="part[@name=('assessment','assessment-method')]/prop[@name='method']"/>   
+   
+   <xsl:template match="part[@name=('assessment','assessment-objects')]/p">
+      <p>
+         <xsl:copy-of select="@*"/>
+         <input type="checkbox"/>
+         <xsl:text> </xsl:text>
+         <xsl:apply-templates mode="#current"/>
+      </p>
+   </xsl:template>   
    
    <xsl:template match="part[@name='item'] | part[@name='objective']">
       <div class="part">
          <xsl:copy-of select="@id"/>
          <xsl:apply-templates select="." mode="title"/>
-         <table class="objective-part">
+         <table class="{ @name }-part">
             <tbody>
                <tr>
                   <td>
@@ -227,21 +236,50 @@
                <xsl:apply-templates select="." mode="summary-title"/>
             </summary>
             <table class="objective-part">
-            <tbody>
-               <tr>
-                  <td>
-                     <xsl:apply-templates select="." mode="part-number"/>
-                  </td>
-                  <td>
-                     <xsl:apply-templates/>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
+               <tbody>
+                  <tr>
+                     <td>
+                        <xsl:apply-templates select="." mode="part-number"/>
+                     </td>
+                     <td>
+                        <xsl:apply-templates/>
+                     </td>
+                  </tr>
+               </tbody>
+            </table>
          </details>
-         
-         
       </div>
+   </xsl:template>
+   
+   <xsl:template priority="3" match="control/part[@name='assessment-objective']">
+      <div class="part">
+         <xsl:copy-of select="@id"/>
+         <details>
+            <summary>
+               <xsl:apply-templates select="." mode="summary-title"/>
+            </summary>
+            <table class="objective-table">
+               <tbody>
+                  <xsl:apply-templates mode="assessment-table"/>
+               </tbody>
+            </table>
+         </details>
+      </div>
+   </xsl:template>
+   
+   <xsl:template priority="5" mode="assessment-table" match="part[@name='assessment-objective']//part[@name='assessment-objective']">
+      <xsl:apply-templates mode="#current"/>
+   </xsl:template>
+   
+   <xsl:template priority="8" mode="assessment-table" match="part[@name='assessment-objective'][exists(p)]">
+      <tr>
+         <td class="assessment-label">
+           <xsl:apply-templates select="." mode="part-number"/>
+         </td>
+         <td>
+            <xsl:apply-templates/>
+         </td>
+      </tr>
    </xsl:template>
    
    <xsl:template match="*" mode="summary-title">
@@ -268,7 +306,7 @@
    <xsl:template match="part" mode="part-number"/>
    
    <xsl:template match="part[prop/@name='label']" mode="part-number">
-      <xsl:apply-templates mode="#current" select="prop[@name='label']"/>
+      <xsl:apply-templates mode="#current" select="prop[@name='label'][1]"/>
    </xsl:template>
    
    <xsl:template match="prop" mode="part-number">
@@ -305,10 +343,24 @@
       </h4>
    </xsl:template>
    
+   <xsl:template priority="2" match="part[@name='assessment-objective']" mode="title">
+      <h4>
+         <xsl:text>Assessment Objective</xsl:text>
+         <xsl:if test="part">s</xsl:if>
+      </h4>
+   </xsl:template>
+   
+   <xsl:template priority="2" match="part[@name='assessment-method']" mode="title">
+      <h4>
+         <xsl:text>Assessment Method: </xsl:text>
+         <xsl:value-of select="prop[@name='method']/@value"/>
+      </h4>
+   </xsl:template>
+   
    <xsl:template  priority="2" match="part[@name='assessment']" mode="title">
       <h4>
          <xsl:text>Assessment: </xsl:text>
-         <xsl:value-of select="prop[@name='method']"/>
+         <xsl:value-of select="prop[@name='method']/@value"/>
       </h4>
    </xsl:template>
    

--- a/xslt/publish/nist-emulation/sp800-53A-catalog_html.xsl
+++ b/xslt/publish/nist-emulation/sp800-53A-catalog_html.xsl
@@ -8,6 +8,20 @@
 
    <xsl:import href="../generic-preview/oscal_catalog_html.xsl"/>
    
+<!--  
+   
+   
+   x  confirm run on old data / tweak
+   x confirm run on new data
+   x run to PDF
+   o rename 'objective-part' as 'statement-part'?
+   x paste screen shot
+   o update comments
+   o PR
+   o CSX: catalog display
+   
+   -->
+   
    <!-- Space can be stripped from anything modeled as an assembly. -->
    <xsl:strip-space elements="catalog group control param guideline select part
       metadata back-matter annotation party person org rlink address resource role responsible-party citation
@@ -213,7 +227,7 @@
       <div class="part">
          <xsl:copy-of select="@id"/>
          <xsl:apply-templates select="." mode="title"/>
-         <table class="{ @name }-part">
+         <table class="objective-part">
             <tbody>
                <tr>
                   <td>
@@ -260,7 +274,7 @@
             </summary>
             <table class="objective-table">
                <tbody>
-                  <xsl:apply-templates mode="assessment-table"/>
+                  <xsl:apply-templates select="." mode="assessment-table"/>
                </tbody>
             </table>
          </details>
@@ -521,7 +535,7 @@
    </xsl:template>
    
    <xsl:template match="back-matter/resource">
-      <tr class="resource" id="{@uuid}">
+      <tr class="resource" id="resource-{@uuid}">
          <xsl:apply-templates/>
       </tr>
    </xsl:template>

--- a/xslt/publish/readme.md
+++ b/xslt/publish/readme.md
@@ -205,16 +205,31 @@ Since this XSLT is a customization of the generic preview (HTML) XSLT, it accept
 
 ### PDF production
 
-PDF production is supported by an XSLT 3.0 transformation applied to the HTML (either 'preview' or 'NIST emulation') produced in earlier steps.
-
-A command line for producing a PDF version of the "NIST emulation" HTML, will look like this:
+PDF production is supported by an XSLT 3.0 transformation applied to the *HTML (either 'preview' or 'NIST emulation') produced in earlier steps*.
 
 ```bash
-> ./fop -xml name.xml -xsl name2fo.xsl -pdf name.pdf
+java -cp saxon-he-10.0.jar net.sf.saxon.Transform -t -s:latest-catalog-pre-fo.html -xsl:nist-emulation/oscal_sp800-53-emulator_fo.xsl -o:latest-catalog-formatted.fo
 ```
 
-Note that in order to work, however, the script `fop.sh` will have been modified to call SaxonHE instead of the built-in Java transformation engine (Xalan), which is used by default.
+This produces an XML instance (with file suffix `.fo`) suitable for processing directly in Apache FOP (see [Apache FOP documentation](https://xmlgraphics.apache.org/fop/0.95/running.html) for more info.
 
+```bash
+> ./fop -fo latest-catalog-formatted.fo -pdf name.pdf
+```
+
+Alternatively, these two steps can be combined into one by a script that calls a transformation internally before invoking Xalan.
+
+In general, a command line for producing a PDF version of the "NIST emulation" HTML, can be constructed in the form:
+
+```bash
+> ./fop -xml latest-catalog-formatted.html -xsl nist-emulation/oscal_sp800-53-emulator_fo.xsl -pdf latest-catalog-formatted.pdf
+```
+
+In this configuration, the first stage of the two-step process is embedded. In order to work with these stylesheets, however, the script `fop.sh` will have been modified to call SaxonHE instead of the built-in Java transformation engine (Xalan), which is used by default.
+
+The two transformations (producing HTML and FO format representations) can also be chained with the third (PDF production from FO format) for an end-to-end OSCAL-to-PDF pipeline.
+
+XML desktop applications, editors or IDEs may have support for XSL-FO based transformations (using FOP or a commercial engine) built in, along with features to support these configurations and others (for example, using them as libraries for other transformations).
 
 ## Customization
 

--- a/xslt/publish/readme.md
+++ b/xslt/publish/readme.md
@@ -3,6 +3,10 @@
 
 The repository provides XSLT transformations that together form a starter/demo OSCAL publishing platform. The stylesheets are in the public domain, and are designed to be freely used, adapted, and reverse engineered.
 
+For all work in this repository the standard NIST DISCLAIMER applies, as documented here: https://www.nist.gov/disclaimer
+
+(Also copied below as of February 2022.)
+
 XSLT transformations can be applied to XML data to produce results (outputs) in various formats, including other forms of XML, HTML or PDF (for processing by software that know how to read those formats). Since this is a publishing application (that is, aiming at legible display for human readers), we aim at HTML (readily installed into any web site) and PDF.
 
 Neither the HTML nor the PDF outputs produced by this software is or can be warranted for any purpose. They are published mainly for the purpose of providing baseline functionality, as a starting point for others.
@@ -62,7 +66,7 @@ The stylesheets described, however, can be used inside any architecture or stack
 
 ### XSLT dependencies
 
-The XSLT is documented internally, but developers can assume that features of XSLT 3.0 are sometimes exploited, meaning these stylesheets will not always run correctly, unaltered, in an XSLT 1.0 environment.
+The XSLT is documented internally, but developers can assume that features of XSLT 3.0 are sometimes exploited, meaning these stylesheets will generally not run correctly, unaltered, in an XSLT 1.0 environment.
 
 The Saxon processor from Saxonica.com is the leading XSLT 3.0 processor and has been used for testing. Its open-source version is recommended. However, the XSLT code is conformant to standards and should also run in any (conformant) XSLT 3.0 engine.
 
@@ -199,6 +203,7 @@ A command line for producing a PDF version of the "NIST emulation" HTML, will lo
 
 ```bash
 > ./fop -xml name.xml -xsl name2fo.xsl -pdf name.pdf
+```
 
 Note that in order to work, however, the script `fop.sh` will have been modified to call SaxonHE instead of the built-in Java transformation engine (Xalan), which is used by default.
 
@@ -206,3 +211,18 @@ Note that in order to work, however, the script `fop.sh` will have been modified
 ## Customization
 
 Either or both of these XSLT transformations may be further customized, either by direct intervention or by importing or including into local/customizing XSLT stylesheets.
+
+## NIST DISCLAIMER STATEMENT
+
+Also see https://www.nist.gov/disclaimer.
+
+> ### Software Disclaimer
+>
+> NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+> 
+> NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+> 
+> You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+> 
+> [See the NIST Privacy, Security Notice, and Accessibility Statement](https://www.nist.gov/property-fieldsection/privacy-statementsecuritynoticeaccessibility-statement)
+> [More information about copyright, fair use and licensing for SRD, data and software](https://www.nist.gov/open/copyright-fair-use-and-licensing-statements-srd-data-software-and-technical-series-publications)

--- a/xslt/publish/readme.md
+++ b/xslt/publish/readme.md
@@ -11,6 +11,14 @@ XSLT transformations can be applied to XML data to produce results (outputs) in 
 
 Neither the HTML nor the PDF outputs produced by this software is or can be warranted for any purpose. They are published mainly for the purpose of providing baseline functionality, as a starting point for others.
 
+## XSLT Version
+
+Unless marked otherwise, assume that XSLT in this repository conforms to version 3.0 and may exploit 3.0 features. Accordingly it will not run in older XSLT engines: at least Saxon version 10 is recommended (any platform or license, or the free-to-use Saxon 10 HE).
+
+Some stylesheets may conform to older versions including XSLT 1.0 for use in browsers, but these will be special purpose.
+
+See more below under "XSLT Dependencies".
+
 ## Summary of XSLT transformations available
 
 ### Producing HTML (web pages)

--- a/xslt/readme.md
+++ b/xslt/readme.md
@@ -14,3 +14,10 @@ Although at different stages of development, for the most part these resources h
 `lib` - miscelleneous tooling at different stages of maturity
 
 `publish` - publishing OSCAL in HTML and PDF formats
+
+## XSLT Version
+
+Unless marked otherwise, assume that XSLT in this repository conforms to version 3.0 and may exploit 3.0 features. Accordingly it will not run in older XSLT engines: at least Saxon version 10 is recommended (any platform or license, or the free-to-use Saxon 10 HE).
+
+Some stylesheets may conform to older versions including XSLT 1.0 for use in browsers, but these will be special purpose.
+


### PR DESCRIPTION
Updated XSLT produces HTML and PDF nicely from current as well as (most) older variants of OSCAL SP800-53.

This PR also addresses issue #26, with enhancements to readme files.
