### PR TITLE
Update DAP code, close usnistgov/oscal-tools#74.

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -11,7 +11,7 @@ languages:
     weight: 1
 MetaDataFormat: "yaml"
 theme: "uswds"
-googleAnalytics: UA-42404149-54
+googleAnalytics: UA-66610693-1
 enableGitInfo: true
 pygmentsCodeFences: true
 pygmentsCodefencesGuessSyntax: true


### PR DESCRIPTION
Closes #74, see usnistgov/OSCAL#1413 for background and original fix reported for one of our sites, not all.